### PR TITLE
Updates for forward-stationing m4 branch

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject marathon-schemas "4.1.7-SNAPSHOT"
+(defproject marathon-schemas "4.1.8-SNAPSHOT"
   :description "data schemas, specifications, and validation tools for marathon"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"

--- a/src/marathon/schemas.clj
+++ b/src/marathon/schemas.clj
@@ -151,7 +151,8 @@
      [:Priority :int]
      ;;Added for SRM ;;need to allow these to parse loosely...
      {:optional ;;annotated to ensure these show up in the ^:optional meta
-      [:Command
+      [[:Tags :clojure] ;;marathon.ces.sampledata does not have tags
+       :Command
        :Location
        :DemandType
        :Theater

--- a/src/marathon/spec.clj
+++ b/src/marathon/spec.clj
@@ -297,6 +297,7 @@
 (def likelihoods (spread-squares 5 2));; This is more extendable, and
 ;; two samples are almost always inscope.  One sample might not be.
 
+;;Should shuffle the range here every time we load this namespace.
 (def src-sets (map (fn [src] #{(str src)}) (range (count
                                                    likelihoods))))
 (def src-gens (map s/gen src-sets))

--- a/src/marathon/spec.clj
+++ b/src/marathon/spec.clj
@@ -246,5 +246,15 @@
 ;;defining the marathon specs
 (s/def :DemandRecords/Tags2 (s/and :marathon.spec/Tags :DemandRecords/Tags ))
 
-;;SupplyRecords/Component #{"AC", "NG", "RA"}
+;;SupplyRecord/Component #{"AC", "NG", "RA"}
 ;;SupplyRecords can't have two records for the same SRC, Component
+;;DemandRecord/SRC and SupplyRecord/SRC
+;;make it more likely to get in scope results with
+;;(def likelihoods [7 14 21 26 32]) ;;This didn't look skewed enough
+(def likelihoods [1 6 13 30 50])
+(def src-sets (map (fn [src] #{(str src)}) (range (count
+                                                   likelihoods))))
+(def src-gens (map s/gen src-sets))
+(def more-likely (gen/frequency
+                  (map vector likelihoods src-gens)))
+


### PR DESCRIPTION
Required to merge the forward-stationing m4 branch into master because I'm using this for one of the new tests in there.  :Tags weren't in the schemas before and before the maybe-type fix, all projects would pass the spec.  Also started speccing forward-stationing inputs.